### PR TITLE
Removing crypto currency wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@ Note: All DNS names are valid in the route1337.com internet facing zone file. It
 
 Donate To Support These Vagrant Boxes
 ------------
-Route 1337, LLC operates entirely on donations. If you find these Vagrant boxes useful, please consider donating via one of these methods.
-
-1. Bitcoin: 1CnzzrPh3iirEkLRLiWFKXDV9i5TXHQjE2
-2. Bitcoin Cash: qzcq645swgd87s7t5mmmjcumf4armhtjt5euww5c29
-3. Litecoin: LWYbc9hf5ErJsF874Q3wwmMiASHRWgwrjR
-4. Ethereum: 0x117543aa7a4D704849171cA06568Ece71B111D18
+Route 1337, LLC operates entirely on donations. If you find these scripts useful, please consider [contacting us](https://www.route1337.com/contact-us/) about how to donate.
 
 Thank you for your support!


### PR DESCRIPTION
The crypto currency wallet provider randomly rotates the IDs
so we have to remove them or risk donations going to unknown
places.